### PR TITLE
Fix typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ In the simplest case you need to provide 3 forms of the noun and a number. Those
 ```javascript
 import { polishPlurals } from 'polish-plurals';
 
-polishPlural("komentarz", "komentarze", "komentarzy", 1); // komentarz
-polishPlural("komentarz", "komentarze", "komentarzy", 0); // komentarzy
-polishPlural("komentarz", "komentarze", "komentarzy", 3); // komentarze
+polishPlurals("komentarz", "komentarze", "komentarzy", 1); // komentarz
+polishPlurals("komentarz", "komentarze", "komentarzy", 0); // komentarzy
+polishPlurals("komentarz", "komentarze", "komentarzy", 3); // komentarze
 ```
 
 ### Binding


### PR DESCRIPTION
The 's' was missing from the function invocation, which confused the
hell outta me (for like 5 seconds, but still!).